### PR TITLE
Drop HHVM testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ php:
   - 7.0
   - 7.1
   - 7.2
-  - hhvm
 
 before_script:
   - composer self-update
@@ -19,14 +18,11 @@ before_script:
   - composer require --dev cache/array-adapter || true
   
   # Set memory limit to 2 MB
-  - if [[ $TRAVIS_PHP_VERSION != hhvm* ]]; then echo "memory_limit=2048M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
+  - echo "memory_limit=2048M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   
   # Disable X-debug on all but PHP 5.6
-  - if [[ $TRAVIS_PHP_VERSION != hhvm* ]] && [ "$TRAVIS_PHP_VERSION" != "5.6" ]; then phpenv config-rm xdebug.ini; fi
+  - if [ "$TRAVIS_PHP_VERSION" != "5.6" ]; then phpenv config-rm xdebug.ini; fi
   
-  # Disable JIT compilation in HHVM
-  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo 'hhvm.jit = 0' >> /etc/hhvm/php.ini; fi
-
 script:
   - vendor/bin/phpcs --standard=PSR1,PSR2 -n src
 


### PR DESCRIPTION
HHVM LTS 3.24 is the last version to support PHP 5 compatibility
third paragraph states "HHVM will not aim to target PHP7" and further down "We do not intend to be the runtime of choice for folks with pure PHP7 code." (just HACK)
https://hhvm.com/blog/2017/09/18/the-future-of-hhvm.html