### PR TITLE
Fix a list of supported device types

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,23 +385,29 @@ The `type` property can contain any value from the following list:
 
 * desktop
 * mobile
+* pda
+* dect
 * tablet
 * gaming
-* headset
 * ereader
 * media
+* headset
+* watch
 * emulator
 * television
 * monitor
 * camera
+* printer
 * signage
 * whiteboard
+* devboard
+* inflight
+* appliance
+* gps
 * car
 * pos
 * bot
-* devboard
-* gps
-* watch
+* projector
 
 If the `type` is "mobile", the `subtype` property can contain any value from the following list:
 

--- a/README.md
+++ b/README.md
@@ -399,6 +399,9 @@ The `type` property can contain any value from the following list:
 * car
 * pos
 * bot
+* devboard
+* gps
+* watch
 
 If the `type` is "mobile", the `subtype` property can contain any value from the following list:
 


### PR DESCRIPTION
I found that the parser can define some types of devices that are not described in the documentation. This PR fixes this.