### PR TITLE
Deprecated use of implode

### DIFF
--- a/src/Model/Primitive/Base.php
+++ b/src/Model/Primitive/Base.php
@@ -76,6 +76,6 @@ class Base
             }
         }
 
-        return implode($lines, ", ");
+        return implode(", ", $lines);
     }
 }

--- a/src/Model/Version.php
+++ b/src/Model/Version.php
@@ -251,7 +251,7 @@ class Version extends Base
                     }
                 }
 
-                $version .= implode($v, '.');
+                $version .= implode('.', $v);
 
                 if (array_key_exists(5, $match) && strlen($match[5])) {
                     $version .= $match[5] . (!empty($match[6]) ? $match[6] : '');


### PR DESCRIPTION
In PHP 7.4 the argument order must now be implode($glue, $parts) instead of implode($parts, $glue) which used to be valid.