### PR TITLE
Add Mac OS 11 (Big Sur)

### DIFF
--- a/src/Analyser/Header/Useragent/Os.php
+++ b/src/Analyser/Header/Useragent/Os.php
@@ -98,11 +98,11 @@ trait Os
         elseif (preg_match('/Mac OS X/u', $ua) || preg_match('/;os=Mac/u', $ua)) {
             $this->data->os->name = 'OS X';
 
-            if (preg_match('/Mac OS X (10[0-9\._]*)/u', $ua, $match)) {
+            if (preg_match('/Mac OS X (1[0-9][0-9\._]*)/u', $ua, $match)) {
                 $this->data->os->version = new Version([ 'value' => str_replace('_', '.', $match[1]), 'details' => 2 ]);
             }
 
-            if (preg_match('/;os=Mac (10[0-9[\.,]*)/u', $ua, $match)) {
+            if (preg_match('/;os=Mac (1[0-9][0-9[\.,]*)/u', $ua, $match)) {
                 $this->data->os->version = new Version([ 'value' => str_replace(',', '.', $match[1]), 'details' => 2 ]);
             }
 

--- a/tests/data/desktop/browser-chrome.yaml
+++ b/tests/data/desktop/browser-chrome.yaml
@@ -64,5 +64,5 @@
     readable: 'Chrome 10 on Linux'
 -
     headers: 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.67 Safari/537.36'
-    result: { browser: { name: Chrome, version: 87.0.4280.67, type: browser }, engine: { name: Webkit, version: '537.36' }, os: { name: 'OS X', alias: 'Mac OS X', version: '11.0' }, device: { type: desktop, manufacturer: Apple, model: Macintosh } }
-    readable: 'Chrome 87.0.4280.67 on Mac OS X 11.0'
+    result: { browser: { name: Chrome, version: 87.0.4280.67, type: browser }, engine: { name: Blink }, os: { name: 'OS X', alias: macOS, version: { value: '11.0', nickname: 'Big Sur' } }, device: { type: desktop, manufacturer: Apple, model: Macintosh } }
+    readable: 'Chrome Dev 87.0.4280.67 on macOS Big Sur 11.0'

--- a/tests/data/desktop/browser-chrome.yaml
+++ b/tests/data/desktop/browser-chrome.yaml
@@ -62,3 +62,7 @@
     headers: 'User-Agent: Mozilla/5.0 (X11; U; Linux x86_64; en-US) AppleWebKit/534.16 (KHTML, like Gecko) Chrome/10.0.648.11 Safari/534.16'
     result: { browser: { name: Chrome, version: '10', type: browser }, engine: { name: Webkit, version: '534.16' }, os: { name: Linux }, device: { type: desktop } }
     readable: 'Chrome 10 on Linux'
+-
+    headers: 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.67 Safari/537.36'
+    result: { browser: { name: Chrome, version: 87.0.4280.67, type: browser }, engine: { name: Webkit, version: '537.36' }, os: { name: 'OS X', alias: 'Mac OS X', version: '11.0' }, device: { type: desktop, manufacturer: Apple, model: Macintosh } }
+    readable: 'Chrome 87.0.4280.67 on Mac OS X 11.0'


### PR DESCRIPTION
See github issue: https://github.com/WhichBrowser/Parser-PHP/issues/620

macOS Big Sur (version 11) details: https://en.wikipedia.org/wiki/MacOS_Big_Sur

Updated testing repo: https://github.com/ayumi-cloud/Parser-PHP-v3.x.x/releases/tag/3.0.1
