### PR TITLE
Add extra browser specific http headers

### DIFF
--- a/src/Analyser/Header.php
+++ b/src/Analyser/Header.php
@@ -62,11 +62,11 @@ trait Header
         }
         
         if ($header = $this->getHeader('X-Bolt-Phone-UA')) {
-            $this->analyseBaiduHeader($header);
+            $this->analyseBoltHeader($header);
         }
         
         if ($header = $this->getHeader('X-Skyfire-Phone')) {
-            $this->analyseBaiduHeader($header);
+            $this->analyseSkyfireHeader($header);
         }
 
         /* Analyse Android WebView browser ids */
@@ -95,6 +95,16 @@ trait Header
     private function analyseBaiduHeader($header)
     {
         new Header\Baidu($header, $this->data);
+    }
+
+    private function analyseBoltHeader($header)
+    {
+        new Header\Bolt($header, $this->data);
+    }
+
+    private function analyseSkyfireHeader($header)
+    {
+        new Header\Skyfire($header, $this->data);
     }
 
     private function analyseOperaMiniPhone($header)

--- a/src/Analyser/Header.php
+++ b/src/Analyser/Header.php
@@ -61,6 +61,13 @@ trait Header
             $this->analyseBaiduHeader($header);
         }
         
+        if ($header = $this->getHeader('X-Bolt-Phone-UA')) {
+            $this->analyseBaiduHeader($header);
+        }
+        
+        if ($header = $this->getHeader('X-Skyfire-Phone')) {
+            $this->analyseBaiduHeader($header);
+        }
 
         /* Analyse Android WebView browser ids */
 

--- a/src/Analyser/Header/Bolt.php
+++ b/src/Analyser/Header/Bolt.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WhichBrowser\Analyser\Header;
+
+class Bolt
+{
+    public function __construct($header, &$data)
+    {
+        $this->data =& $data;
+
+        if (!isset($this->data->browser->name) || $this->data->browser->name != 'Baidu Browser') {
+            $this->data->browser->name = 'Baidu Browser';
+            $this->data->browser->version = null;
+            $this->data->browser->stock = false;
+        }
+    }
+}

--- a/src/Analyser/Header/Bolt.php
+++ b/src/Analyser/Header/Bolt.php
@@ -8,8 +8,8 @@ class Bolt
     {
         $this->data =& $data;
 
-        if (!isset($this->data->browser->name) || $this->data->browser->name != 'Baidu Browser') {
-            $this->data->browser->name = 'Baidu Browser';
+        if (!isset($this->data->browser->name) || $this->data->browser->name != 'Bolt Browser') {
+            $this->data->browser->name = 'Bolt Browser';
             $this->data->browser->version = null;
             $this->data->browser->stock = false;
         }

--- a/src/Analyser/Header/Skyfire.php
+++ b/src/Analyser/Header/Skyfire.php
@@ -8,8 +8,8 @@ class Skyfire
     {
         $this->data =& $data;
 
-        if (!isset($this->data->browser->name) || $this->data->browser->name != 'Baidu Browser') {
-            $this->data->browser->name = 'Baidu Browser';
+        if (!isset($this->data->browser->name) || $this->data->browser->name != 'SkyFire Browser') {
+            $this->data->browser->name = 'SkyFire Browser';
             $this->data->browser->version = null;
             $this->data->browser->stock = false;
         }

--- a/src/Analyser/Header/Skyfire.php
+++ b/src/Analyser/Header/Skyfire.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WhichBrowser\Analyser\Header;
+
+class Skyfire
+{
+    public function __construct($header, &$data)
+    {
+        $this->data =& $data;
+
+        if (!isset($this->data->browser->name) || $this->data->browser->name != 'Baidu Browser') {
+            $this->data->browser->name = 'Baidu Browser';
+            $this->data->browser->version = null;
+            $this->data->browser->stock = false;
+        }
+    }
+}


### PR DESCRIPTION
The headers that tend to store the real useragents are:

Opera Mini - HTTP_X_OPERAMINI_PHONE_UA
Opera Mini (legacy) - HTTP_X_OPERAMINI_FEATURES
Opera Mobile - HTTP_DEVICE_STOCK_UA
SkyFire Browser - HTTP_X_SKYFIRE_PHONE
Bolt Browser - HTTP_X_BOLT_PHONE_UA
UCBrowser - HTTP_X_UCBROWSER_DEVICE_UA
Common Browser Proxies - HTTP_X_ORIGINAL_USER_AGENT
Web Forms - HTTP_X_DEVICE_USER_AGENT

This pr adds `SkyFire Browser` and `Bolt Browser` to the analyse browser specific headers section.
