### PR TITLE
Add more regex for `Go http package`

### DIFF
--- a/data/applications-bots.php
+++ b/data/applications-bots.php
@@ -384,8 +384,8 @@ Applications::$BOTS = [
     [ 'name' => 'Node Fetch',                   'id'    => 'node',      'regexp' => '/node-fetch\/([0-9.]*)/u' ],
     [ 'name' => 'Wget',                         'id'    => 'wget',      'regexp' => '/Wget\/([0-9.]*)/u' ],
     [ 'name' => 'Curl',                         'id'    => 'curl',      'regexp' => '/^curl\/([0-9.]*)/u' ],
-
     [ 'name' => 'Go',                           'id'    => 'package',      'regexp' => '/Go [0-9\.]+ package http/u' ],
+    [ 'name' => 'Go',                           'id'    => 'package',      'regexp' => '/Go http package/u' ],
     [ 'name' => 'Java',                         'id'    => 'java',      'regexp' => '/^Java\/([0-9.]*)/u' ],
     [ 'name' => 'Perl',                         'id'    => 'simple',      'regexp' => '/LWP::Simple\//u' ],
     [ 'name' => 'Perl',                         'id'    => 'libwww',      'regexp' => '/libwww-perl\//u' ],

--- a/tests/data/bots/generic.yaml
+++ b/tests/data/bots/generic.yaml
@@ -998,3 +998,7 @@
     headers: 'User-Agent: Mozilla/5.0 zgrab/0.x'
     readable: Zgrab
     result: { browser: { name: Zgrab }, device: { type: bot } }
+-
+    headers: 'User-Agent: Go http package'
+    readable: Go
+    result: { browser: { name: Go }, device: { type: bot } }


### PR DESCRIPTION
Added extra regex as this pattern also hitting our test servers.

Link: https://golang.org/pkg/net/http/
