### PR TITLE
Add `Cloudflare SSL Detector` bot

### DIFF
--- a/data/applications-bots.php
+++ b/data/applications-bots.php
@@ -76,6 +76,7 @@ Applications::$BOTS = [
     [ 'name' => 'Cloudflare Diagnostics',       'id'    => 'cloudflare',      'regexp' => '/Cloudflare Diagnostics/u' ],
     [ 'name' => 'Cloudflare Diagnostics',       'id'    => 'cloudflare',      'regexp' => '/Cloudflare-Diagnostics/u' ],
     [ 'name' => 'Cloudflare SpeedTest',         'id'    => 'cloudflare',      'regexp' => '/Cloudflare SpeedTest\/([0-9.]*)/u' ],
+    [ 'name' => 'Cloudflare SSL Detector',      'id'    => 'cloudflare',      'regexp' => '/Cloudflare-SSLDetector/u' ],
     [ 'name' => 'Coccocbot Web',                'id'    => 'coccoc',      'regexp' => '/coccocbot-web\/([0-9.]*)/u' ],
     [ 'name' => 'Coccocbot Image',              'id'    => 'coccoc',      'regexp' => '/coccocbot-image\/([0-9.]*)/u' ],
     [ 'name' => 'Comodo',                       'id'    => 'comodo',      'regexp' => '/Comodo Spider ([0-9.]*)/u' ],

--- a/tests/data/bots/generic.yaml
+++ b/tests/data/bots/generic.yaml
@@ -998,3 +998,7 @@
     headers: 'User-Agent: Mozilla/5.0 zgrab/0.x'
     readable: Zgrab
     result: { browser: { name: Zgrab }, device: { type: bot } }
+-
+    headers: 'User-Agent: Cloudflare-SSLDetector'
+    readable: 'Cloudflare SSL Detector'
+    result: { browser: { name: 'Cloudflare SSL Detector' }, device: { type: bot } }


### PR DESCRIPTION
Have noticed this bot from Cloudflare servers hitting some of our test serves several times now.

I previously created pr: https://github.com/WhichBrowser/Parser-PHP/commit/b699e473d160d1d868144e0c065f7886229c068a

But at the time didn't know about this bot, so this pr expands that previous pr.

Open discussion here: https://community.cloudflare.com/t/useragent-cloudflare-ssldetector-being-detected-is-this-a-real-feature-in-cloudflare/248084