### PR TITLE
[TASK] Remove PHP 8.2 exceptions

### DIFF
--- a/src/Analyser/Header/Baidu.php
+++ b/src/Analyser/Header/Baidu.php
@@ -4,6 +4,8 @@ namespace WhichBrowser\Analyser\Header;
 
 class Baidu
 {
+    protected $data;
+
     public function __construct($header, &$data)
     {
         $this->data =& $data;

--- a/src/Analyser/Header/BrowserId.php
+++ b/src/Analyser/Header/BrowserId.php
@@ -9,6 +9,8 @@ use WhichBrowser\Model\Version;
 
 class BrowserId
 {
+    protected $data;
+
     public function __construct($header, &$data)
     {
         if ($header == 'XMLHttpRequest') {

--- a/src/Analyser/Header/OperaMini.php
+++ b/src/Analyser/Header/OperaMini.php
@@ -7,6 +7,8 @@ use WhichBrowser\Constants;
 
 class OperaMini
 {
+    protected $data;
+
     public function __construct($header, &$data)
     {
         $this->data =& $data;

--- a/src/Analyser/Header/Puffin.php
+++ b/src/Analyser/Header/Puffin.php
@@ -6,6 +6,8 @@ use WhichBrowser\Data;
 
 class Puffin
 {
+    protected $data;
+
     public function __construct($header, &$data)
     {
         $this->data =& $data;

--- a/src/Analyser/Header/UCBrowserNew.php
+++ b/src/Analyser/Header/UCBrowserNew.php
@@ -8,6 +8,8 @@ use WhichBrowser\Model\Version;
 
 class UCBrowserNew
 {
+    protected $data;
+
     public function __construct($header, &$data)
     {
         $this->data =& $data;

--- a/src/Analyser/Header/UCBrowserOld.php
+++ b/src/Analyser/Header/UCBrowserOld.php
@@ -7,6 +7,8 @@ use WhichBrowser\Constants;
 
 class UCBrowserOld
 {
+    protected $data;
+
     public function __construct($header, &$data)
     {
         $this->data =& $data;

--- a/src/Analyser/Header/Useragent.php
+++ b/src/Analyser/Header/Useragent.php
@@ -6,6 +6,9 @@ class Useragent
 {
     use Useragent\Os, Useragent\Device, Useragent\Browser, Useragent\Application, Useragent\Using, Useragent\Engine, Useragent\Bot;
 
+    protected $data;
+    protected $options;
+
     public function __construct($header, &$data, &$options)
     {
         $this->data =& $data;

--- a/src/Analyser/Header/Wap.php
+++ b/src/Analyser/Header/Wap.php
@@ -7,6 +7,8 @@ use WhichBrowser\Data;
 
 class Wap
 {
+    protected $data;
+
     public function __construct($header, &$data)
     {
         $this->data =& $data;


### PR DESCRIPTION
Before this commit E_DEPRECATED exception is thrown in PHP 8.2. Like: Creation of dynamic property Useragent::$data is deprecated

Related: https://github.com/WhichBrowser/Parser-PHP/issues/676