### PR TITLE
Tests: stop autoloading with the rest of the production build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 
     "autoload": {
         "psr-4": {
-            "WhichBrowser\\": [ "src/", "tests/src/" ]
+            "WhichBrowser\\": [ "src/" ]
         }
     },
 

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
 
     "autoload-dev": {
        "psr-4": {
-            "WhichBrowserTest\\":  "tests/unit"
+            "WhichBrowserTest\\":  "tests/unit",
+            "WhichBrowser\\": [ "tests/src/" ]
         },
 
         "files": [ "tests/src/polyfills.php" ]

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <phpunit
-    bootstrap="./vendor/autoload.php"
+    bootstrap="tests/src/bootstrap.php"
     colors="false"
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"

--- a/tests/src/bootstrap.php
+++ b/tests/src/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Bootstrap tests.
+ *
+ * @package WhichBrowser/Parser-PHP
+ */
+
+/**
+ * Include the composer autoloader.
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';


### PR DESCRIPTION
Fixes #679

### Changes suggested in this Pull Request

Instead of autoloading the tests by default (they do not get shipped with the production version of the package), let's bootstrap them separately, just for the tests.

**To do**

- [x] ~This breaks `bin/runner.php`. I am not familiar with this repo so I do not know how this is used. I'll let someone else who is more comfortable with this repository make suggestions :)~ This was fixed in 77a681d7bc20d54212e5b343ae1bb5dfa1594c72
